### PR TITLE
Store and restore OT processors

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 
 import torch
 from diffusers import StableDiffusionXLPipeline, AutoencoderKL
@@ -68,6 +69,9 @@ def parse_args():
     parser.add_argument(
         "--num_images_per_prompt", type=int, default=4, help="number of images per prompt"
     )
+    parser.add_argument(
+        "--ot_weights", type=str, default=None, help="path to distilled OT weights"
+    )
     return parser.parse_args()
 
 
@@ -100,14 +104,29 @@ if __name__ == '__main__':
     # Load
     pipeline.load_lora_into_unet(res_lora, None, pipeline.unet)
 
-    # Replace attention processors with Sinkhorn OT
+    # Replace attention processors with Sinkhorn OT and optionally load weights
     OT_BLOCKS = ['up_blocks.0.attentions.0', 'up_blocks.0.attentions.1']
+    ot_state = {}
+    if args.ot_weights is not None:
+        ot_state = torch.load(args.ot_weights, map_location="cpu")
     for attn_processor_name, _ in pipeline.unet.attn_processors.items():
         if any(attn_processor_name.startswith(b) for b in OT_BLOCKS):
             attn_module = pipeline.unet
             for n in attn_processor_name.split('.')[:-1]:
                 attn_module = getattr(attn_module, n)
-            attn_module.set_processor(SinkhornOTAttnProcessor())
+            head_dim = getattr(attn_module, "head_dim", None)
+            if head_dim is None:
+                num_heads = getattr(attn_module, "num_heads", None)
+                if num_heads is None:
+                    num_heads = getattr(attn_module, "heads", None)
+                if num_heads is not None:
+                    head_dim = attn_module.to_q.out_features // num_heads
+                else:
+                    head_dim = attn_module.to_q.out_features
+            ot_proc = SinkhornOTAttnProcessor(head_dim)
+            if attn_processor_name in ot_state:
+                ot_proc.load_state_dict(ot_state[attn_processor_name])
+            attn_module.set_processor(ot_proc)
 
     # Generate
     images = pipeline(args.prompt, num_images_per_prompt=args.num_images_per_prompt).images

--- a/train_dreambooth_ot-lora_sdxl.py
+++ b/train_dreambooth_ot-lora_sdxl.py
@@ -154,6 +154,24 @@ def text_encoder_lora_state_dict(text_encoder):
     return state_dict
 
 
+def unet_ot_state_dict(unet):
+    """Return the state dict of all SinkhornOTAttnProcessor layers in the UNet."""
+    state_dict = {}
+    attn_procs = getattr(unet, "attn_processors", {})
+    for name, proc in attn_procs.items():
+        if isinstance(proc, SinkhornOTAttnProcessor):
+            state_dict[name] = proc.state_dict()
+    return state_dict
+
+
+def load_ot_into_unet(unet, state_dict):
+    """Load OT processor weights into the UNet."""
+    attn_procs = getattr(unet, "attn_processors", {})
+    for name, proc in attn_procs.items():
+        if name in state_dict and isinstance(proc, SinkhornOTAttnProcessor):
+            proc.load_state_dict(state_dict[name])
+
+
 def save_model_card(
         repo_id: str,
         images=None,
@@ -995,9 +1013,21 @@ def filter_lora_layers(lora_state_dict: dict, groups: list) -> dict:
 
 def compute_ot_distill_loss(unet):
     model = unet.module if hasattr(unet, "module") else unet
+
+    # Collect attention processors either from the dedicated attribute or
+    # by traversing the module tree for submodules that expose a `processor`
+    processors = []
+    attn_procs = getattr(model, "attn_processors", None)
+    if attn_procs is not None:
+        processors.extend(attn_procs.values())
+    else:
+        for module in model.modules():
+            if hasattr(module, "processor"):
+                processors.append(module.processor)
+
     loss = 0.0
-    for proc in model.attn_processors.values():
-        if isinstance(proc, SinkhornOTAttnProcessor) and proc.last_ot is not None:
+    for proc in processors:
+        if isinstance(proc, SinkhornOTAttnProcessor) and getattr(proc, "last_ot", None) is not None:
             loss = loss + F.mse_loss(proc.last_ot, proc.last_soft)
     return loss
 
@@ -1286,12 +1316,14 @@ def main(args):
             # there are only two options here. Either are just the unet attn processor layers
             # or there are the unet and text encoder atten layers
             unet_lora_layers_to_save = None
+            unet_ot_layers_to_save = None
             text_encoder_one_lora_layers_to_save = None
             text_encoder_two_lora_layers_to_save = None
 
             for model in models:
                 if isinstance(model, type(accelerator.unwrap_model(unet))):
                     unet_lora_layers_to_save = unet_lora_state_dict(model)
+                    unet_ot_layers_to_save = unet_ot_state_dict(model)
                 elif isinstance(
                         model, type(accelerator.unwrap_model(text_encoder_one))
                 ):
@@ -1316,6 +1348,8 @@ def main(args):
                 text_encoder_lora_layers=text_encoder_one_lora_layers_to_save,
                 text_encoder_2_lora_layers=text_encoder_two_lora_layers_to_save,
             )
+            if unet_ot_layers_to_save is not None:
+                torch.save(unet_ot_layers_to_save, os.path.join(output_dir, "unet_ot.bin"))
 
     def load_model_hook(models, input_dir):
         unet_ = None
@@ -1338,6 +1372,11 @@ def main(args):
         LoraLoaderMixin.load_lora_into_unet(
             lora_state_dict, network_alphas=network_alphas, unet=unet_
         )
+
+        ot_path = os.path.join(input_dir, "unet_ot.bin")
+        if os.path.isfile(ot_path):
+            ot_state = torch.load(ot_path, map_location="cpu")
+            load_ot_into_unet(unet_, ot_state)
 
         text_encoder_state_dict = {
             k: v for k, v in lora_state_dict.items() if "text_encoder." in k
@@ -2049,6 +2088,7 @@ def main(args):
             text_encoder_lora_layers=text_encoder_lora_layers,
             text_encoder_2_lora_layers=text_encoder_2_lora_layers,
         )
+        torch.save(unet_ot_state_dict(unet), os.path.join(args.output_dir, "unet_ot.bin"))
 
         # remove unuse models for save GPU memory
         unet = unet.cpu()
@@ -2091,6 +2131,10 @@ def main(args):
 
         # load attention processors
         pipeline.load_lora_weights(args.output_dir)
+        ot_path = os.path.join(args.output_dir, "unet_ot.bin")
+        if os.path.isfile(ot_path):
+            ot_state = torch.load(ot_path, map_location="cpu")
+            load_ot_into_unet(pipeline.unet, ot_state)
 
         # run inference
         images = []


### PR DESCRIPTION
## Summary
- expose helpers to save/load SinkhornOTAttnProcessor weights
- persist OT weights when saving checkpoints
- reload OT weights for validation and during resume
- allow inference to load distilled OT processors via `--ot_weights`

## Testing
- `python -m py_compile train_dreambooth_ot-lora_sdxl.py inference.py`

------
https://chatgpt.com/codex/tasks/task_e_6845af331140832cb42a026d063753ac