### PR TITLE
Fix total_steps calculation

### DIFF
--- a/train_dreambooth_ot-lora_sdxl.py
+++ b/train_dreambooth_ot-lora_sdxl.py
@@ -1634,6 +1634,10 @@ def main(args):
         args.max_train_steps = args.num_train_epochs * num_update_steps_per_epoch
         overrode_max_train_steps = True
 
+    # Compute total optimization steps before creating the scheduler so it can
+    # be used for learning rate scheduling.
+    total_steps = args.max_train_steps + args.pretrain_ot_steps
+
     lr_scheduler = get_scheduler(
         args.lr_scheduler,
         optimizer=optimizer,


### PR DESCRIPTION
## Summary
- compute `total_steps` before creating the scheduler in `train_dreambooth_ot-lora_sdxl.py`
- ensure learning-rate scheduler receives correct total step count

## Testing
- `python -m py_compile train_dreambooth_ot-lora_sdxl.py`
- `python train_dreambooth_ot-lora_sdxl.py --help` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68462c386538832c90908083f7448e36