### PR TITLE
Improve OT distillation utilities

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -13,6 +13,8 @@ class SinkhornOTAttnProcessor:
     def __init__(self, n_iters: int = 20, eps: float = 1e-3):
         self.n_iters = n_iters
         self.eps = eps
+        self.last_ot = None
+        self.last_soft = None
 
     def _sinkhorn(self, log_scores):
         for _ in range(self.n_iters):
@@ -37,7 +39,9 @@ class SinkhornOTAttnProcessor:
         if attention_mask is not None:
             attn_scores = attn_scores + attention_mask
 
+        self.last_soft = torch.softmax(attn_scores, dim=-1)
         attn_probs = self._sinkhorn(attn_scores)
+        self.last_ot = attn_probs
 
         hidden_states = torch.bmm(attn_probs, value)
         hidden_states = attn.batch_to_head_dim(hidden_states)

--- a/ot_inference.py
+++ b/ot_inference.py
@@ -1,0 +1,116 @@
+import argparse
+import os
+
+import torch
+import torch.nn as nn
+from diffusers import StableDiffusionXLPipeline, AutoencoderKL, UNet2DConditionModel
+
+
+class SinkhornOTAttnProcessor(nn.Module):
+    """Sinkhorn Optimal Transport attention processor."""
+
+    def __init__(self, head_dim: int, n_iters: int = 5, eps: float = 1e-2):
+        super().__init__()
+        self.n_iters = n_iters
+        self.log_eps = nn.Parameter(torch.log(torch.tensor(eps)))
+        self.q_cost = nn.Linear(head_dim, head_dim, bias=False)
+        self.k_cost = nn.Linear(head_dim, head_dim, bias=False)
+        self.last_ot: torch.Tensor | None = None
+        self.last_soft: torch.Tensor | None = None
+
+    def _sinkhorn(self, scores: torch.Tensor) -> torch.Tensor:
+        for _ in range(self.n_iters):
+            scores = scores - torch.logsumexp(scores, dim=-1, keepdim=True)
+            scores = scores - torch.logsumexp(scores, dim=-2, keepdim=True)
+        return scores.exp()
+
+    def forward(
+        self,
+        attn,
+        hidden_states,
+        encoder_hidden_states=None,
+        attention_mask=None,
+        **kwargs,
+    ):
+        residual = hidden_states
+        if encoder_hidden_states is None:
+            encoder_hidden_states = hidden_states
+        q = attn.to_q(hidden_states)
+        k = attn.to_k(encoder_hidden_states)
+        v = attn.to_v(encoder_hidden_states)
+
+        q = attn.head_to_batch_dim(q)
+        k = attn.head_to_batch_dim(k)
+        v = attn.head_to_batch_dim(v)
+
+        qc = self.q_cost(q)
+        kc = self.k_cost(k)
+        cost = (
+            qc.pow(2).sum(-1, keepdim=True)
+            + kc.pow(2).sum(-1).unsqueeze(-2)
+            - 2 * qc @ kc.transpose(-1, -2)
+        )
+        log_scores = -cost / torch.exp(self.log_eps)
+        if attention_mask is not None:
+            log_scores = log_scores + attention_mask
+
+        self.last_soft = torch.softmax(log_scores, dim=-1)
+        transport = self._sinkhorn(log_scores)
+        self.last_ot = transport
+
+        hidden_states = transport @ v
+        hidden_states = attn.batch_to_head_dim(hidden_states)
+        hidden_states = attn.to_out[0](hidden_states)
+        hidden_states = attn.to_out[1](hidden_states)
+        return hidden_states + residual
+
+
+def inject_ot_attention(unet: UNet2DConditionModel, n_iters: int = 5, eps: float = 1e-2):
+    for name, _ in unet.attn_processors.items():
+        if name.endswith("attn2"):
+            attn_module = unet
+            for sub in name.split(".")[:-1]:
+                attn_module = getattr(attn_module, sub)
+            head_dim = getattr(attn_module, "head_dim", None)
+            if head_dim is None:
+                head_dim = attn_module.to_q.out_features // attn_module.num_heads
+            attn_module.set_processor(SinkhornOTAttnProcessor(head_dim, n_iters=n_iters, eps=eps))
+
+
+def load_pipeline(base: str, ot_weights: str | None = None, lora_weights: str | None = None):
+    vae = AutoencoderKL.from_pretrained("madebyollin/sdxl-vae-fp16-fix")
+    pipe = StableDiffusionXLPipeline.from_pretrained(base, vae=vae, torch_dtype=torch.float16)
+    inject_ot_attention(pipe.unet)
+    if ot_weights:
+        state = torch.load(ot_weights, map_location="cpu")
+        for name, proc in pipe.unet.attn_processors.items():
+            if name in state:
+                proc.load_state_dict(state[name])
+    if lora_weights:
+        sd = torch.load(lora_weights, map_location="cpu")
+        pipe.unet.load_state_dict(sd, strict=False)
+    pipe.to("cuda")
+    return pipe
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="OT-attention inference script")
+    parser.add_argument("--model", type=str, default="stabilityai/stable-diffusion-xl-base-1.0")
+    parser.add_argument("--prompt", type=str, required=True)
+    parser.add_argument("--ot_weights", type=str, default=None)
+    parser.add_argument("--lora_weights", type=str, default=None)
+    parser.add_argument("--num_images", type=int, default=1)
+    parser.add_argument("--output_dir", type=str, default="ot_outputs")
+    return parser.parse_args()
+
+
+def main(args):
+    pipe = load_pipeline(args.model, args.ot_weights, args.lora_weights)
+    os.makedirs(args.output_dir, exist_ok=True)
+    images = pipe(args.prompt, num_images_per_prompt=args.num_images).images
+    for i, img in enumerate(images):
+        img.save(os.path.join(args.output_dir, f"img_{i}.png"))
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/train_train_dreambooth_ot-style-lora.py
+++ b/train_train_dreambooth_ot-style-lora.py
@@ -24,9 +24,10 @@ from typing import List, Tuple
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 from diffusers import StableDiffusionXLPipeline, UNet2DConditionModel, AutoencoderKL
 from peft import LoraConfig, get_peft_model
-from transformers import AutoTokenizer
+from transformers import AutoTokenizer, CLIPTextModel
 
 
 # -----------------------------------------------------------------------------
@@ -87,6 +88,8 @@ class SinkhornOTAttnProcessor(nn.Module):
         self.log_eps = nn.Parameter(torch.log(torch.tensor(eps)))
         self.q_cost = nn.Linear(head_dim, head_dim, bias=False)
         self.k_cost = nn.Linear(head_dim, head_dim, bias=False)
+        self.last_ot: torch.Tensor | None = None
+        self.last_soft: torch.Tensor | None = None
 
     def _sinkhorn(self, scores: torch.Tensor) -> torch.Tensor:
         for _ in range(self.n_iters):
@@ -119,7 +122,10 @@ class SinkhornOTAttnProcessor(nn.Module):
         log_scores = -cost / torch.exp(self.log_eps)
         if attention_mask is not None:
             log_scores = log_scores + attention_mask
+
+        self.last_soft = torch.softmax(log_scores, dim=-1)
         transport = self._sinkhorn(log_scores)
+        self.last_ot = transport
         hidden_states = transport @ v
         hidden_states = attn.batch_to_head_dim(hidden_states)
         hidden_states = attn.to_out[0](hidden_states)
@@ -143,7 +149,7 @@ def inject_ot_attention(unet: UNet2DConditionModel, n_iters: int = 5, eps: float
 
 def apply_lora(unet: UNet2DConditionModel, rank: int = 8):
     lora_cfg = LoraConfig(r=rank, target_modules=["to_q", "to_v", "q_cost", "k_cost", "log_eps"])
-    get_peft_model(unet, lora_cfg)
+    return get_peft_model(unet, lora_cfg)
 
 
 # -----------------------------------------------------------------------------
@@ -156,9 +162,12 @@ def ot_distillation_loop(unet: UNet2DConditionModel, dataloader, optimizer, n_st
         if step >= n_steps:
             break
         noisy_latents, encoder_hidden_states = batch
-        preds = unet(noisy_latents, encoder_hidden_states=encoder_hidden_states).sample
-        mse = ((unet.attn_processors[list(unet.attn_processors.keys())[0]].last_soft -
-                unet.attn_processors[list(unet.attn_processors.keys())[0]].last_ot) ** 2).mean()
+        timesteps = torch.randint(0, 1000, (noisy_latents.shape[0],), device=noisy_latents.device)
+        _ = unet(noisy_latents, timesteps, encoder_hidden_states=encoder_hidden_states).sample
+        mse = 0.0
+        for proc in unet.attn_processors.values():
+            if isinstance(proc, SinkhornOTAttnProcessor) and proc.last_ot is not None:
+                mse = mse + F.mse_loss(proc.last_ot, proc.last_soft)
         mse.backward()
         optimizer.step()
         optimizer.zero_grad(set_to_none=True)
@@ -174,7 +183,11 @@ def style_lora_finetune(unet: UNet2DConditionModel, dataloader, optimizer, n_ste
         if step >= n_steps:
             break
         noisy_latents, noise_pred = batch
-        pred = unet(noisy_latents).sample
+        timesteps = torch.randint(0, 1000, (noisy_latents.shape[0],), device=noisy_latents.device)
+        encoder_hidden_states = torch.randn(
+            noisy_latents.shape[0], 77, unet.config.cross_attention_dim, device=noisy_latents.device
+        )
+        pred = unet(noisy_latents, timesteps, encoder_hidden_states=encoder_hidden_states).sample
         loss = ((pred - noise_pred) ** 2).mean()
         loss.backward()
         optimizer.step()
@@ -207,7 +220,7 @@ def load_pipeline(base: str, ot_weights: str | None = None, lora_weights: str | 
 
 def main(args):
     tokenizer = AutoTokenizer.from_pretrained(args.tokenizer)
-    text_encoder = StableDiffusionXLPipeline.from_pretrained(args.model, subfolder="text_encoder").text_encoder
+    text_encoder = CLIPTextModel.from_pretrained(args.model, subfolder="text_encoder")
 
     # Prompt OT decomposition
     res = prompt_ot_split(args.prompt, tokenizer, text_encoder)
@@ -217,7 +230,7 @@ def main(args):
     # Prepare UNet
     unet = UNet2DConditionModel.from_pretrained(args.model, subfolder="unet")
     inject_ot_attention(unet)
-    apply_lora(unet)
+    unet = apply_lora(unet)
 
     # Dummy dataloaders & optimizers here (placeholders for real code)
     dummy_data = [(


### PR DESCRIPTION
## Summary
- log softmax and OT matrices in `SinkhornOTAttnProcessor`
- gather OT distillation loss from all attention processors
- return the `PeftModel` when applying LoRA and use it for training
- pass timesteps and encoder states to the UNet during dummy training
- load CLIP text encoder directly rather than through the pipeline
- add `ot_inference.py` for testing OT attention inference

## Testing
- `python -m py_compile train_train_dreambooth_ot-style-lora.py inference.py ot_inference.py`


------
https://chatgpt.com/codex/tasks/task_e_6846c60a3b04832ca5f1117a638d7423